### PR TITLE
fix: syntax for standard link in local-dev-env-setup

### DIFF
--- a/docs/observe/local-dev-env-setup.md
+++ b/docs/observe/local-dev-env-setup.md
@@ -117,5 +117,5 @@ Run the below command to start the local development setup
 docker-compose up -d
 ```
 
-> Goto <http://localhost:16686/> to see the Jaeger UI.
-> Goto <http://localhost:9090> to see the Prometheus UI.
+> Goto [http://localhost:16686/](http://localhost:16686/) to see the Jaeger UI.
+> Goto [http://localhost:9090](http://localhost:9090) to see the Prometheus UI.


### PR DESCRIPTION


RCA:
- The Syntax for inserting links was not followed. The compiler came across invalid characters(`<` , `>`) in `local-dev-env-setup.md`

Changes:
- Refactor to Use Proper Syntax for Standard Links.