### PR TITLE
ingestion:add oauth2client extension in service in kube helm setup

### DIFF
--- a/docs/telemetry-ingestion/kubernetes-helm-setup.md
+++ b/docs/telemetry-ingestion/kubernetes-helm-setup.md
@@ -110,7 +110,7 @@ scout:
             insecure_skip_verify: true
 
       service:
-        extensions: [health_check, pprof, zpages]
+        extensions: [health_check, pprof, zpages, oauth2client]
         pipelines:
           traces:
             receivers: [otlp]


### PR DESCRIPTION
RCA:
Error:
{"error": "failed to resolve authenticator \"oauth2client\": authenticator not found", "type": "Exporter", "id": "otlphttp/base14"} 

Changes:
- Add `oauth2client` extension in service block for kubernetes helm setup.