### PR TITLE
update otel collector deployment for ecs doc

### DIFF
--- a/configs/ecs/ec2/task-definition.json
+++ b/configs/ecs/ec2/task-definition.json
@@ -24,7 +24,7 @@
       ],
       "cpu": 256,
       "memory": 512,
-      "image": "otel/opentelemetry-collector-contrib:0.127.0",
+      "image": "otel/opentelemetry-collector-contrib:0.130.0",
       "essential": true,
       "command": [
         "--config=env:SCOUT_CONFIG_CONTENT"
@@ -32,11 +32,11 @@
       "mountPoints": [],
       "volumesFrom": [],
       "name": "${TASK_NAME}",
-      "environment": [
+      "secrets": [
         {
           "name": "SCOUT_CONFIG_CONTENT",
-          "value": "${SCOUT_CONFIG_CONTENT}",
-        },
+          "valueFrom": "${SECRET_NAME}"
+        }
       ],
       "systemControls": [],
     },

--- a/configs/ecs/fargate/task-definition.json
+++ b/configs/ecs/fargate/task-definition.json
@@ -24,7 +24,7 @@
       ],
       "cpu": 256,
       "memory": 512,
-      "image": "otel/opentelemetry-collector-contrib:0.127.0",
+      "image": "otel/opentelemetry-collector-contrib:0.130.0",
       "essential": true,
       "command": [
         "--config=env:SCOUT_CONFIG_CONTENT"
@@ -32,19 +32,19 @@
       "mountPoints": [],
       "volumesFrom": [],
       "name": "${TASK_NAME}",
-      "environment": [
+      "secrets": [
         {
           "name": "SCOUT_CONFIG_CONTENT",
-          "value": "${SCOUT_CONFIG_CONTENT}",
-        },
+          "valueFrom": "${SECRET_NAME}"
+        }
       ],
       "systemControls": [],
     },
   ],
   "family": "${SERVICE_NAME}",
   "requiresCompatibilities": [
-    "EC2"
+    "FARGATE"
   ],
-  "networkMode": "bridge",
+  "networkMode": "awsvpc",
   "volumes": [],
 }


### PR DESCRIPTION
Changes:
- Add Sections to deploy scout collector as daemonset in managed node
- Add Sections to deploy scout collector as service in manged node.
- Add Section to deploy scout collector as sidecar in fargate node.