### PR TITLE
📝 docs: OTel pipeline processor ordering across all configs

### DIFF
--- a/docs/guides/cicd-observability/argocd.md
+++ b/docs/guides/cicd-observability/argocd.md
@@ -246,7 +246,7 @@ service:
   pipelines:
     metrics:
       receivers: [prometheus]
-      processors: [batch, resource]
+      processors: [resource, batch]
       exporters: [otlphttp/b14]
 ```
 
@@ -305,7 +305,7 @@ service:
   pipelines:
     metrics:
       receivers: [prometheus]
-      processors: [batch, resource]
+      processors: [resource, batch]
       exporters: [otlphttp/b14]
 ```
 

--- a/docs/instrument/apps/auto-instrumentation/fastify.md
+++ b/docs/instrument/apps/auto-instrumentation/fastify.md
@@ -408,15 +408,15 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch, resource]
+      processors: [resource, batch]
       exporters: [otlphttp/scout]
     metrics:
       receivers: [otlp]
-      processors: [batch, resource]
+      processors: [resource, batch]
       exporters: [otlphttp/scout]
     logs:
       receivers: [otlp]
-      processors: [batch, resource]
+      processors: [resource, batch]
       exporters: [otlphttp/scout]
 ```
 

--- a/docs/instrument/collector-setup/kubernetes-helm-setup.md
+++ b/docs/instrument/collector-setup/kubernetes-helm-setup.md
@@ -294,43 +294,43 @@ scout:
         pipelines:
           traces:
             receivers: [otlp]
-            processors: [batch]
+            processors: [memory_limiter, batch]
             exporters: [otlphttp/base14]
           logs:
             receivers: [otlp]
-            processors: [batch]
+            processors: [memory_limiter, batch]
             exporters: [otlphttp/base14]
           logs/k8s-events:
             receivers: [ k8sobjects]
             processors: [
               memory_limiter,
-              batch,
               resource/k8s-events,
               resourcedetection/eks,
-              resource/env ]
+              resource/env,
+              batch ]
             exporters: [ otlphttp/base14 ]
           logs/k8s-cluster:
             receivers: [ k8s_cluster ]
             processors: [
               memory_limiter,
-              batch,
               resource/k8s,
               resourcedetection/eks,
-              resource/env ]
+              resource/env,
+              batch ]
             exporters: [ otlphttp/base14 ]
           metrics:
             receivers: [ otlp ]
-            processors: [ memory_limiter, batch, resource/env ]
+            processors: [ memory_limiter, resource/env, batch ]
             exporters: [ otlphttp/base14 ]
           metrics/k8s:
             receivers: [ k8s_cluster ]
             processors: [
               memory_limiter,
-              batch,
               resource/k8s,
               resourcedetection/eks,
               resource/env,
-              k8sattributes ]
+              k8sattributes,
+              batch ]
             exporters: [ otlphttp/base14 ]
         telemetry:
           logs:
@@ -505,26 +505,26 @@ scout:
         pipelines:
           traces:
             receivers: [otlp]
-            processors: [batch, resource, resource/env]
+            processors: [memory_limiter, resource, resource/env, batch]
             exporters: [otlp/agent]
           logs:
             receivers: [otlp, filelog]
-            processors: [batch, resource/env]
+            processors: [memory_limiter, resource/env, batch]
             exporters: [otlp/agent]
           metrics:
             receivers: [otlp]
-            processors: [memory_limiter, batch, resource/env]
+            processors: [memory_limiter, resource/env, batch]
             exporters: [otlp/agent]
           metrics/k8s:
             receivers: [kubeletstats]
             processors:
               [
                 memory_limiter,
-                batch,
                 resource/k8s,
                 resourcedetection/eks,
                 resource/env,
                 k8sattributes,
+                batch,
               ]
             exporters: [otlp/agent]
         telemetry:
@@ -710,43 +710,43 @@ scout:
         pipelines:
           traces:
             receivers: [ otlp]
-            processors: [ batch, resource, resource/env ]
+            processors: [ memory_limiter, resource, resource/env, batch ]
             exporters: [ otlphttp/base14 ]
           logs:
             receivers: [ otlp ]
-            processors: [ batch, resource/env ]
+            processors: [ memory_limiter, resource/env, batch ]
             exporters: [ otlphttp/base14, debug ]
           logs/k8s-events:
             receivers: [ k8sobjects]
             processors: [
               memory_limiter,
-              batch,
               resource/k8s-events,
               resourcedetection/eks,
-              resource/env ]
+              resource/env,
+              batch ]
             exporters: [ otlphttp/base14 ]
           logs/k8s-cluster:
             receivers: [ k8s_cluster ]
             processors: [
               memory_limiter,
-              batch,
               resource/k8s,
               resourcedetection/eks,
-              resource/env ]
+              resource/env,
+              batch ]
             exporters: [ otlphttp/base14 ]
           metrics:
             receivers: [ otlp ]
-            processors: [ memory_limiter, batch, resource/env ]
+            processors: [ memory_limiter, resource/env, batch ]
             exporters: [ otlphttp/base14 ]
           metrics/k8s:
             receivers: [ k8s_cluster ]
             processors: [
               memory_limiter,
-              batch,
               resource/k8s,
               resourcedetection/eks,
               resource/env,
-              k8sattributes ]
+              k8sattributes,
+              batch ]
             exporters: [ otlphttp/base14 ]
         telemetry:
           logs:

--- a/docs/instrument/collector-setup/otel-collector-config.md
+++ b/docs/instrument/collector-setup/otel-collector-config.md
@@ -191,11 +191,11 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch, memory_limiter]
+      processors: [memory_limiter, batch]
       exporters: [otlp, zipkin]
     metrics:
       receivers: [otlp, prometheus]
-      processors: [batch, memory_limiter]
+      processors: [memory_limiter, batch]
       exporters: [otlp, prometheus]
     logs:
       receivers: [otlp]
@@ -440,11 +440,11 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch, attributes, resourcedetection]
+      processors: [attributes, resourcedetection, batch]
       exporters: [otlp/traces]
     metrics:
       receivers: [otlp, prometheus]
-      processors: [batch, resourcedetection]
+      processors: [resourcedetection, batch]
       exporters: [otlp/metrics, prometheus]
 ```
 

--- a/docs/instrument/component/clickhouse.md
+++ b/docs/instrument/component/clickhouse.md
@@ -149,7 +149,7 @@ service:
   pipelines:
     metrics:
       receivers: [prometheus]
-      processors: [batch, resource]
+      processors: [resource, batch]
       exporters: [otlphttp/b14]
 ```
 

--- a/docs/instrument/component/envoy.md
+++ b/docs/instrument/component/envoy.md
@@ -135,7 +135,7 @@ service:
   pipelines:
     metrics:
       receivers: [prometheus]
-      processors: [batch, resource]
+      processors: [resource, batch]
       exporters: [otlphttp/b14]
 ```
 

--- a/docs/instrument/component/mariadb.md
+++ b/docs/instrument/component/mariadb.md
@@ -183,7 +183,7 @@ service:
   pipelines:
     metrics:
       receivers: [mysql]
-      processors: [batch, resource]
+      processors: [resource, batch]
       exporters: [otlphttp/b14]
 ```
 

--- a/docs/instrument/component/minio.md
+++ b/docs/instrument/component/minio.md
@@ -143,7 +143,7 @@ service:
   pipelines:
     metrics:
       receivers: [prometheus]
-      processors: [batch, resource]
+      processors: [resource, batch]
       exporters: [otlphttp/b14]
 ```
 

--- a/docs/instrument/component/mongodb.md
+++ b/docs/instrument/component/mongodb.md
@@ -181,7 +181,7 @@ service:
   pipelines:
     metrics:
       receivers: [mongodb]
-      processors: [batch, resource]
+      processors: [resource, batch]
       exporters: [otlphttp/b14]
 ```
 

--- a/docs/instrument/component/mysql.md
+++ b/docs/instrument/component/mysql.md
@@ -184,7 +184,7 @@ service:
   pipelines:
     metrics:
       receivers: [mysql]
-      processors: [batch, resource]
+      processors: [resource, batch]
       exporters: [otlphttp/b14]
 ```
 

--- a/docs/instrument/component/nats.md
+++ b/docs/instrument/component/nats.md
@@ -166,7 +166,7 @@ service:
   pipelines:
     metrics:
       receivers: [prometheus]
-      processors: [batch, resource]
+      processors: [resource, batch]
       exporters: [otlphttp/b14]
 ```
 

--- a/docs/instrument/component/nomad.md
+++ b/docs/instrument/component/nomad.md
@@ -147,7 +147,7 @@ service:
   pipelines:
     metrics:
       receivers: [prometheus]
-      processors: [batch, resource]
+      processors: [resource, batch]
       exporters: [otlphttp/b14]
 ```
 

--- a/docs/instrument/component/postgres-advanced.md
+++ b/docs/instrument/component/postgres-advanced.md
@@ -211,11 +211,11 @@ service:
   pipelines:
     metrics:
       receivers: [prometheus]
-      processors: [batch, resource]
+      processors: [resource, batch]
       exporters: [otlp/scout]
     traces:
       receivers: [otlp]
-      processors: [batch, resource]
+      processors: [resource, batch]
       exporters: [otlp/scout]
 ```
 

--- a/docs/instrument/component/postgres.md
+++ b/docs/instrument/component/postgres.md
@@ -205,7 +205,7 @@ service:
   pipelines:
     metrics:
       receivers: [postgresql]
-      processors: [batch, resource]
+      processors: [resource, batch]
       exporters: [otlphttp/b14]
 ```
 

--- a/docs/instrument/component/redis.md
+++ b/docs/instrument/component/redis.md
@@ -178,7 +178,7 @@ service:
   pipelines:
     metrics:
       receivers: [redis]
-      processors: [batch, resource]
+      processors: [resource, batch]
       exporters: [otlphttp/b14]
 ```
 

--- a/docs/instrument/component/traefik.md
+++ b/docs/instrument/component/traefik.md
@@ -150,7 +150,7 @@ service:
   pipelines:
     metrics:
       receivers: [prometheus]
-      processors: [batch, resource]
+      processors: [resource, batch]
       exporters: [otlphttp/b14]
 ```
 

--- a/docs/instrument/infra/aws/elasticache.md
+++ b/docs/instrument/infra/aws/elasticache.md
@@ -164,7 +164,7 @@ service:
   pipelines:
     metrics:
       receivers: [redis]
-      processors: [batch, resource]
+      processors: [resource, batch]
       exporters: [otlphttp/b14]
 ```
 

--- a/docs/instrument/infra/aws/rds.md
+++ b/docs/instrument/infra/aws/rds.md
@@ -197,7 +197,7 @@ service:
   pipelines:
     metrics:
       receivers: [postgresql]
-      processors: [batch, resource]
+      processors: [resource, batch]
       exporters: [otlphttp/b14]
 ```
 

--- a/docs/operate/filters-and-transformations/filtering-pgx-metrics.md
+++ b/docs/operate/filters-and-transformations/filtering-pgx-metrics.md
@@ -117,7 +117,7 @@ service:
   pipelines:
     metrics:
       receivers: [prometheus]
-      processors: [filter/drop_table_index, batch, resource]
+      processors: [filter/drop_table_index, resource, batch]
       exporters: [otlp/scout]
 ```
 
@@ -339,8 +339,8 @@ service:
           filter/drop_table_index,
           filter/drop_test_databases,
           filter/drop_progress_system,
-          batch,
           resource,
+          batch,
         ]
       exporters: [otlp/scout]
 ```


### PR DESCRIPTION
Apply the same convention used in opentelemetry-operator-setup.md across every other doc with OTel collector configs:

- memory_limiter first (drops data on memory pressure before expensive work)
- transforms/filters/resource processors in the middle
- batch last (community recommendation; running transforms after batch wastes work and risks inconsistent attributes within a batch)

Also fixes a critical bug in otel-collector-config.md where memory_limiter was placed AFTER batch in two pipelines, defeating its safety purpose.

Files touched: kubernetes-helm-setup, otel-collector-config, filtering-pgx-metrics, fastify, argocd, and 14 component/infra docs.