### PR TITLE
📝 docs(scout-cli): document --environment flag across logs, metrics, traces, service-map and TUI

### DIFF
--- a/docs/scout-cli/scout-access/logs.md
+++ b/docs/scout-cli/scout-access/logs.md
@@ -50,6 +50,7 @@ scout logs <SERVICE> [flags]
 | `--body-only` | bool | `false` | Output only log bodies, one per line. Conflicts with `--raw` |
 | `--discover` | bool | `false` | Show available log metadata instead of querying |
 | `--wide` | bool | `false` | Show full log bodies without truncation |
+| `--environment <ENV>` | string | — | Restrict results to records tagged with this OTel `deployment.environment` (e.g. `production`, `staging`). Records without that resource attribute are filtered out. |
 
 ## Examples
 
@@ -81,6 +82,12 @@ Correlate with a trace:
 
 ```bash
 scout logs payment-service --trace-id abc123def456
+```
+
+Restrict to a specific deployment environment:
+
+```bash
+scout logs payment-service --environment production
 ```
 
 Output only log bodies:

--- a/docs/scout-cli/scout-access/metrics.md
+++ b/docs/scout-cli/scout-access/metrics.md
@@ -43,6 +43,7 @@ scout metrics <SERVICE> [flags]
 | `--search` | string | — | Filter metrics by name substring (case-insensitive) |
 | `--wide` | bool | `false` | Show full descriptions without truncation |
 | `--raw` | bool | `false` | Output JSON |
+| `--environment <ENV>` | string | — | Restrict to metrics emitted by services tagged with this `deployment.environment` (e.g. `production`, `staging`). Services without the tag return no metrics. |
 
 ## Examples
 
@@ -74,6 +75,12 @@ Show full descriptions:
 
 ```bash
 scout metrics payment-service --wide
+```
+
+Restrict to a specific deployment environment:
+
+```bash
+scout metrics payment-service --environment production
 ```
 
 Output as JSON:

--- a/docs/scout-cli/scout-access/service-map.md
+++ b/docs/scout-cli/scout-access/service-map.md
@@ -37,6 +37,7 @@ scout service-map [flags]
 | `--end` | RFC 3339 | — | End time. Requires `--start` |
 | `--raw` | bool | `false` | Output JSON |
 | `--interactive` | bool | `false` | Launch interactive TUI view |
+| `--environment <ENV>` | string | — | Restrict SERVICES and DEPENDENCIES to services tagged for this deployment environment (e.g. `production`, `staging`). Edges are filtered by caller-side environment tag. |
 
 ## Examples
 
@@ -68,6 +69,12 @@ Export as JSON for further analysis:
 
 ```bash
 scout service-map --raw
+```
+
+Restrict to production services only:
+
+```bash
+scout service-map --environment production
 ```
 
 :::tip

--- a/docs/scout-cli/scout-access/traces.md
+++ b/docs/scout-cli/scout-access/traces.md
@@ -48,6 +48,7 @@ scout traces <SERVICE> [flags]
 | `--raw` | bool | `false` | Output JSON |
 | `--discover` | bool | `false` | Show available span metadata instead of querying |
 | `--id` | string | — | Drill into a specific trace by ID. Extends the time window to 60 minutes |
+| `--environment <ENV>` | string | — | Restrict results to records tagged with this OTel `deployment.environment` (e.g. `production`, `staging`). Records without that resource attribute are filtered out. |
 
 ## Examples
 
@@ -85,6 +86,12 @@ Discover available span names and attributes:
 
 ```bash
 scout traces payment-service --discover
+```
+
+Restrict to a specific deployment environment:
+
+```bash
+scout traces payment-service --environment production
 ```
 
 ## Filtering Logic

--- a/docs/scout-cli/scout-access/tui.md
+++ b/docs/scout-cli/scout-access/tui.md
@@ -27,6 +27,18 @@ logs — all from your terminal.
 scout
 ```
 
+To scope every view to a specific deployment environment, pass
+`--environment <ENV>` at the top level (no subcommand):
+
+```bash
+scout --environment production
+```
+
+When set, the services picker, topology refresh, and logs stream are all
+restricted to records carrying that OTel `deployment.environment`. The active
+environment is shown in the status bar alongside the account name
+(e.g. `⬡ snabbit · production`).
+
 :::note
 TUI mode requires an active authentication session. Run
 [`scout login`](./login.md) first.


### PR DESCRIPTION
Adds a `--environment <ENV>` row to each command's Flags table and a short example invocation. tui.md covers the top-level `scout --environment` form (no subcommand) and the new env marker in the status bar.